### PR TITLE
Add chatglm3-6b model

### DIFF
--- a/04_llm/inferenceservice_chatglm3-6b.yaml
+++ b/04_llm/inferenceservice_chatglm3-6b.yaml
@@ -1,0 +1,36 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    openshift.io/display-name: chatglm3-6b
+    serving.kserve.io/deploymentMode: RawDeployment
+  labels:
+    opendatahub.io/dashboard: "true"
+  name: chatglm3-6b
+  namespace: user1
+spec:
+  predictor:
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      modelFormat:
+        name: vLLM
+      name: ""
+      resources:
+        limits:
+          nvidia.com/gpu: "1"
+        requests:
+          nvidia.com/gpu: "1"
+      runtime: vllm-runtime
+      storage:
+        key: aws-connection-minio
+        path: models/chatglm3-6b
+    tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu
+      operator: Exists
+    - effect: PreferNoSchedule
+      key: gpu-workload-only
+      operator: Exists
+    nodeSelector:
+      gpu-node-type: "2"

--- a/04_llm/job_setup_objectstorage.yaml
+++ b/04_llm/job_setup_objectstorage.yaml
@@ -51,12 +51,15 @@ spec:
           git clone https://huggingface.co/intfloat/multilingual-e5-large
           rm -rf multilingual-e5-large/.git
           aws s3 cp --recursive multilingual-e5-large s3://${NAMESPACE}/models/multilingual-e5-large
-          git clone https://huggingface.co/Systran/faster-whisper-large-v3
-          rm -rf faster-whisper-large-v3/.git
-          aws s3 cp --recursive faster-whisper-large-v3 s3://${NAMESPACE}/models/faster-whisper-large-v3
-          mkdir -p /tmp/stablediffusion
-          touch /tmp/stablediffusion/dummy
-          aws s3 cp --recursive /tmp/stablediffusion s3://${NAMESPACE}/models/stablediffusion
+            git clone https://huggingface.co/Systran/faster-whisper-large-v3
+            rm -rf faster-whisper-large-v3/.git
+            aws s3 cp --recursive faster-whisper-large-v3 s3://${NAMESPACE}/models/faster-whisper-large-v3
+            git clone https://huggingface.co/THUDM/chatglm3-6b
+            rm -rf chatglm3-6b/.git
+            aws s3 cp --recursive chatglm3-6b s3://${NAMESPACE}/models/chatglm3-6b
+            mkdir -p /tmp/stablediffusion
+            touch /tmp/stablediffusion/dummy
+            aws s3 cp --recursive /tmp/stablediffusion s3://${NAMESPACE}/models/stablediffusion
           set +e
           aws s3 ls --recursive s3://${NAMESPACE}
         envFrom:

--- a/04_llm/setup.sh
+++ b/04_llm/setup.sh
@@ -55,6 +55,7 @@ oc apply -f inferenceservice_tanuki-8b-dpo-v1-0.yaml -n ${USER}
 oc apply -f inferenceservice_llama-3-elyza-jp-8b.yaml -n ${USER}
 #oc apply -f servingruntime_granite-3-0-8b-instruct-vllm.yaml -n ${USER}
 oc apply -f inferenceservice_granite-3-0-8b-instruct.yaml -n ${USER}
+oc apply -f inferenceservice_chatglm3-6b.yaml -n ${USER}
 
 oc apply -f servingruntime_multilingual-e5-large-hf-tei.yaml -n ${USER}
 oc apply -f inferenceservice_multilingual-e5-large.yaml -n ${USER}
@@ -74,6 +75,9 @@ oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeo
 
 while true; do oc get inferenceservices/granite-3-0-8b-instruct -n ${USER} 2>&1 | grep "not found" 1>/dev/null 2>&1; if [ $? -eq 0 ]; then echo "inferenceservices/granite-3-0-8b-instruct does not exist yet. waiting..."; sleep 3; continue; else break; fi; done
 oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeout 30m inferenceservices/granite-3-0-8b-instruct -n ${USER}
+
+while true; do oc get inferenceservices/chatglm3-6b -n ${USER} 2>&1 | grep "not found" 1>/dev/null 2>&1; if [ $? -eq 0 ]; then echo "inferenceservices/chatglm3-6b does not exist yet. waiting..."; sleep 3; continue; else break; fi; done
+oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeout 30m inferenceservices/chatglm3-6b -n ${USER}
 
 while true; do oc get inferenceservices/multilingual-e5-large -n ${USER} 2>&1 | grep "not found" 1>/dev/null 2>&1; if [ $? -eq 0 ]; then echo "inferenceservices/multilingual-e5-large does not exist yet. waiting..."; sleep 3; continue; else break; fi; done
 oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeout 30m inferenceservices/multilingual-e5-large -n ${USER}

--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -37,7 +37,7 @@ spec:
         - name: AIOHTTP_CLIENT_TIMEOUT
           value: "1600"
         - name: DEFAULT_MODELS
-          value: "phi-4-quantized-w8a8"
+          value: "phi-4-quantized-w8a8,chatglm3-6b"
         - name: RAG_EMBEDDING_ENGINE
           value: "openai"
         - name: RAG_EMBEDDING_MODEL
@@ -72,7 +72,7 @@ spec:
         - name: ENABLE_OLLAMA_API
           value: "false"
         - name: OPENAI_API_BASE_URLS
-          value: "http://phi-4-quantized-w8a8-predictor.user1.svc.cluster.local:8080/v1;http://tanuki-8b-dpo-v1-0-predictor.user1.svc.cluster.local:8080/v1;http://llama-3-elyza-jp-8b-predictor.user1.svc.cluster.local:8080/v1;http://granite-3-0-8b-instruct-predictor.user1.svc.cluster.local:8080/v1"
+          value: "http://phi-4-quantized-w8a8-predictor.user1.svc.cluster.local:8080/v1;http://tanuki-8b-dpo-v1-0-predictor.user1.svc.cluster.local:8080/v1;http://llama-3-elyza-jp-8b-predictor.user1.svc.cluster.local:8080/v1;http://granite-3-0-8b-instruct-predictor.user1.svc.cluster.local:8080/v1;http://chatglm3-6b-predictor.user1.svc.cluster.local:8080/v1"
         - name: OPENAI_API_KEY
           value: "openshift"
         - name: ENABLE_IMAGE_GENERATION


### PR DESCRIPTION
## Summary
- clone chatglm3-6b model into object storage
- deploy new chatglm3-6b InferenceService
- expose chatglm3-6b to Open WebUI defaults
- load chatglm3-6b in setup script

## Testing
- `yamllint 04_llm/inferenceservice_chatglm3-6b.yaml open-webui.yaml 04_llm/job_setup_objectstorage.yaml`
- `bash -n 04_llm/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883198fc05083268ff08d179b9fcb7c