### PR TITLE
Switch to Qwen3-8B-Base model

### DIFF
--- a/04_llm/inferenceservice_qwen3-8b-base.yaml
+++ b/04_llm/inferenceservice_qwen3-8b-base.yaml
@@ -2,11 +2,11 @@ apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
   annotations:
-    openshift.io/display-name: chatglm3-6b
+    openshift.io/display-name: qwen3-8b-base
     serving.kserve.io/deploymentMode: RawDeployment
   labels:
     opendatahub.io/dashboard: "true"
-  name: chatglm3-6b
+  name: qwen3-8b-base
   namespace: user1
 spec:
   predictor:
@@ -24,7 +24,7 @@ spec:
       runtime: vllm-runtime
       storage:
         key: aws-connection-minio
-        path: models/chatglm3-6b
+        path: models/qwen3-8b-base
     tolerations:
     - effect: NoSchedule
       key: nvidia.com/gpu

--- a/04_llm/job_setup_objectstorage.yaml
+++ b/04_llm/job_setup_objectstorage.yaml
@@ -51,9 +51,9 @@ spec:
             git clone https://huggingface.co/Systran/faster-whisper-large-v3
             rm -rf faster-whisper-large-v3/.git
             aws s3 cp --recursive faster-whisper-large-v3 s3://${NAMESPACE}/models/faster-whisper-large-v3
-            git clone https://huggingface.co/THUDM/chatglm3-6b
-            rm -rf chatglm3-6b/.git
-            aws s3 cp --recursive chatglm3-6b s3://${NAMESPACE}/models/chatglm3-6b
+            git clone https://huggingface.co/Qwen/Qwen3-8B-Base
+            rm -rf Qwen3-8B-Base/.git
+            aws s3 cp --recursive Qwen3-8B-Base s3://${NAMESPACE}/models/qwen3-8b-base
             mkdir -p /tmp/stablediffusion
             touch /tmp/stablediffusion/dummy
             aws s3 cp --recursive /tmp/stablediffusion s3://${NAMESPACE}/models/stablediffusion

--- a/04_llm/setup.sh
+++ b/04_llm/setup.sh
@@ -53,7 +53,7 @@ oc apply -f inferenceservice_phi-4-quantized-w8a8.yaml -n ${USER}
 oc apply -f inferenceservice_llama-3-elyza-jp-8b.yaml -n ${USER}
 #oc apply -f servingruntime_granite-3-0-8b-instruct-vllm.yaml -n ${USER}
 oc apply -f inferenceservice_granite-3-0-8b-instruct.yaml -n ${USER}
-oc apply -f inferenceservice_chatglm3-6b.yaml -n ${USER}
+oc apply -f inferenceservice_qwen3-8b-base.yaml -n ${USER}
 
 oc apply -f servingruntime_multilingual-e5-large-hf-tei.yaml -n ${USER}
 oc apply -f inferenceservice_multilingual-e5-large.yaml -n ${USER}
@@ -72,8 +72,8 @@ oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeo
 while true; do oc get inferenceservices/granite-3-0-8b-instruct -n ${USER} 2>&1 | grep "not found" 1>/dev/null 2>&1; if [ $? -eq 0 ]; then echo "inferenceservices/granite-3-0-8b-instruct does not exist yet. waiting..."; sleep 3; continue; else break; fi; done
 oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeout 30m inferenceservices/granite-3-0-8b-instruct -n ${USER}
 
-while true; do oc get inferenceservices/chatglm3-6b -n ${USER} 2>&1 | grep "not found" 1>/dev/null 2>&1; if [ $? -eq 0 ]; then echo "inferenceservices/chatglm3-6b does not exist yet. waiting..."; sleep 3; continue; else break; fi; done
-oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeout 30m inferenceservices/chatglm3-6b -n ${USER}
+while true; do oc get inferenceservices/qwen3-8b-base -n ${USER} 2>&1 | grep "not found" 1>/dev/null 2>&1; if [ $? -eq 0 ]; then echo "inferenceservices/qwen3-8b-base does not exist yet. waiting..."; sleep 3; continue; else break; fi; done
+oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeout 30m inferenceservices/qwen3-8b-base -n ${USER}
 
 while true; do oc get inferenceservices/multilingual-e5-large -n ${USER} 2>&1 | grep "not found" 1>/dev/null 2>&1; if [ $? -eq 0 ]; then echo "inferenceservices/multilingual-e5-large does not exist yet. waiting..."; sleep 3; continue; else break; fi; done
 oc wait --for=jsonpath='{.status.modelStatus.transitionStatus}'=UpToDate --timeout 30m inferenceservices/multilingual-e5-large -n ${USER}

--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -37,7 +37,7 @@ spec:
         - name: AIOHTTP_CLIENT_TIMEOUT
           value: "1600"
         - name: DEFAULT_MODELS
-          value: "phi-4-quantized-w8a8,chatglm3-6b"
+          value: "phi-4-quantized-w8a8,qwen3-8b-base"
         - name: RAG_EMBEDDING_ENGINE
           value: "openai"
         - name: RAG_EMBEDDING_MODEL
@@ -72,7 +72,7 @@ spec:
         - name: ENABLE_OLLAMA_API
           value: "false"
         - name: OPENAI_API_BASE_URLS
-          value: "http://phi-4-quantized-w8a8-predictor.user1.svc.cluster.local:8080/v1;http://llama-3-elyza-jp-8b-predictor.user1.svc.cluster.local:8080/v1;http://granite-3-0-8b-instruct-predictor.user1.svc.cluster.local:8080/v1;http://chatglm3-6b-predictor.user1.svc.cluster.local:8080/v1"
+          value: "http://phi-4-quantized-w8a8-predictor.user1.svc.cluster.local:8080/v1;http://llama-3-elyza-jp-8b-predictor.user1.svc.cluster.local:8080/v1;http://granite-3-0-8b-instruct-predictor.user1.svc.cluster.local:8080/v1;http://qwen3-8b-base-predictor.user1.svc.cluster.local:8080/v1"
         - name: OPENAI_API_KEY
           value: "openshift"
         - name: ENABLE_IMAGE_GENERATION


### PR DESCRIPTION
## Summary
- swap ChatGLM3-6B for Qwen3-8B-Base model
- update object storage setup for new model
- apply new model in setup script
- reference new model in Open WebUI configuration

## Testing
- `bash -n 04_llm/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68870826e948832697f51c992c97f429